### PR TITLE
fix: add dark mode background styling to input elements

### DIFF
--- a/src/components/sheets/SheetsSettingsPanel.tsx
+++ b/src/components/sheets/SheetsSettingsPanel.tsx
@@ -71,7 +71,7 @@ export function SheetsSettingsPanel({
               value={tempInputValue}
               onChange={(e) => onTempInputChange(e.target.value)}
               placeholder={inputPlaceholder}
-              className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-sm"
+              className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-sm bg-white dark:bg-gray-800"
             />
           </div>
           <div className="flex gap-2">

--- a/src/features/exercises/ExercisesTab.tsx
+++ b/src/features/exercises/ExercisesTab.tsx
@@ -58,7 +58,7 @@ export function ExercisesTab() {
               placeholder="Exercise name"
               value={exerciseForm.name}
               onChange={(e) => setExerciseForm({ ...exerciseForm, name: e.target.value })}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800"
             />
             <div className="grid grid-cols-3 gap-2">
               <div>
@@ -68,7 +68,7 @@ export function ExercisesTab() {
                   step="0.5"
                   value={exerciseForm.pct100}
                   onChange={(e) => setExerciseForm({ ...exerciseForm, pct100: e.target.value })}
-                  className="w-full px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+                  className="w-full px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800"
                 />
               </div>
               <div>
@@ -78,7 +78,7 @@ export function ExercisesTab() {
                   step="0.5"
                   value={exerciseForm.pct90}
                   onChange={(e) => setExerciseForm({ ...exerciseForm, pct90: e.target.value })}
-                  className="w-full px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+                  className="w-full px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800"
                 />
               </div>
               <div>
@@ -88,7 +88,7 @@ export function ExercisesTab() {
                   step="0.5"
                   value={exerciseForm.pct80}
                   onChange={(e) => setExerciseForm({ ...exerciseForm, pct80: e.target.value })}
-                  className="w-full px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+                  className="w-full px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800"
                 />
               </div>
             </div>
@@ -100,7 +100,7 @@ export function ExercisesTab() {
                   step="0.5"
                   value={exerciseForm.pct70}
                   onChange={(e) => setExerciseForm({ ...exerciseForm, pct70: e.target.value })}
-                  className="w-full px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+                  className="w-full px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800"
                 />
               </div>
               <div>
@@ -110,7 +110,7 @@ export function ExercisesTab() {
                   step="0.5"
                   value={exerciseForm.pct60}
                   onChange={(e) => setExerciseForm({ ...exerciseForm, pct60: e.target.value })}
-                  className="w-full px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+                  className="w-full px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800"
                 />
               </div>
               <div>
@@ -120,7 +120,7 @@ export function ExercisesTab() {
                   step="0.5"
                   value={exerciseForm.warmup}
                   onChange={(e) => setExerciseForm({ ...exerciseForm, warmup: e.target.value })}
-                  className="w-full px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+                  className="w-full px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800"
                 />
               </div>
             </div>

--- a/src/features/routines/RoutinesTab.tsx
+++ b/src/features/routines/RoutinesTab.tsx
@@ -69,7 +69,7 @@ export function RoutinesTab() {
               }}
               onFocus={() => setShowRoutineSuggestions(true)}
               onBlur={() => setTimeout(() => setShowRoutineSuggestions(false), 200)}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800"
             />
             {showRoutineSuggestions && uniqueRoutines.length > 0 && routineForm.routine && (
               <div className="absolute z-10 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg max-h-32 overflow-y-auto">
@@ -123,7 +123,7 @@ export function RoutinesTab() {
               placeholder="Reps"
               value={routineForm.reps}
               onChange={(e) => setRoutineForm({ ...routineForm, reps: e.target.value })}
-              className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+              className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800"
             />
           </div>
 

--- a/src/features/track/TrackLiftTab.tsx
+++ b/src/features/track/TrackLiftTab.tsx
@@ -93,7 +93,7 @@ export function TrackLiftTab() {
               value={formData.weight}
               onChange={(e) => setFormData({ ...formData, weight: e.target.value })}
               required
-              className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-lg"
+              className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-lg bg-white dark:bg-gray-800"
               placeholder="135"
             />
           </div>
@@ -120,7 +120,7 @@ export function TrackLiftTab() {
               value={formData.reps}
               onChange={(e) => setFormData({ ...formData, reps: e.target.value })}
               required
-              className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-lg"
+              className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-lg bg-white dark:bg-gray-800"
               placeholder="5"
             />
           </div>
@@ -142,7 +142,7 @@ export function TrackLiftTab() {
             type="text"
             value={formData.notes}
             onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-            className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-sm"
+            className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-sm bg-white dark:bg-gray-800"
             placeholder="Optional notes..."
           />
         </div>

--- a/src/features/weight/WeightTab.tsx
+++ b/src/features/weight/WeightTab.tsx
@@ -17,7 +17,7 @@ export function WeightTab() {
               step="0.1"
               value={bodyWeight}
               onChange={(e) => setBodyWeight(e.target.value)}
-              className="w-full px-3 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-lg"
+              className="w-full px-3 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-lg bg-white dark:bg-gray-800"
               placeholder="199.9"
             />
           </div>


### PR DESCRIPTION
Fixes #4

This PR adds proper dark mode styling to all input elements throughout the app.

## Changes
- Added `bg-white dark:bg-gray-800` classes to all input elements
- Fixes issue where inputs had transparent backgrounds in dark mode
- Now inputs are readable with proper dark backgrounds and borders
- Affects inputs in Track, Weight, Exercises, Routines, and Sheets components

## Testing
Toggle dark mode and verify that all input fields are readable with proper background colors.

Generated with [Claude Code](https://claude.ai/code)